### PR TITLE
Fix crash on startup

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id 'fabric-loom' version '0.8-SNAPSHOT'
+	id 'fabric-loom' version '0.9-SNAPSHOT'
 	id 'maven-publish'
 }
 
@@ -49,6 +49,7 @@ tasks.withType(JavaCompile).configureEach {
 
 	// Minecraft 1.17 (21w19a) upwards uses Java 16.
 	it.options.release = 16
+	it.options.deprecation = true
 }
 
 java {
@@ -80,7 +81,7 @@ publishing {
 
 	// See https://docs.gradle.org/current/userguide/publishing_maven.html for information on how to set up publishing.
 	repositories {
-		
+
 		// Add repositories to publish to here.
 		// Notice: This block does NOT have the same function as the block in the top level.
 		// The repositories here will be used for publishing your artifact, not for

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,16 +1,16 @@
 # Done to increase the memory available to gradle.
-org.gradle.jvmargs=-Xmx4G
+org.gradle.jvmargs = -Xmx1G
 
 # Fabric Properties
 	# check these on https://fabricmc.net/versions.html
-	minecraft_version=1.17.1
-	yarn_mappings=1.17.1+build.29
-	loader_version=0.11.6
+	minecraft_version = 1.17.1
+	yarn_mappings = 1.17.1+build.61
+	loader_version = 0.12.1
 
 # Mod Properties
-	mod_version = 1.0.2
+	mod_version = 1.0.2+
 	maven_group = de.kxmischesdomi.boatcontainer
 	archives_base_name = boatcontainer
 
 # Dependencies
-	fabric_version=0.37.1+1.17
+	fabric_version = 0.40.8+1.17

--- a/src/main/java/de/kxmischesdomi/boatcontainer/BoatContainerClient.java
+++ b/src/main/java/de/kxmischesdomi/boatcontainer/BoatContainerClient.java
@@ -3,7 +3,7 @@ package de.kxmischesdomi.boatcontainer;
 import de.kxmischesdomi.boatcontainer.client.renderer.BoatBlockRenderer;
 import de.kxmischesdomi.boatcontainer.common.registry.ModEntities;
 import net.fabricmc.api.ClientModInitializer;
-import net.fabricmc.fabric.api.client.rendereregistry.v1.EntityRendererRegistry;
+import net.fabricmc.fabric.api.client.rendering.v1.EntityRendererRegistry;
 import net.minecraft.block.Blocks;
 
 /**
@@ -14,8 +14,10 @@ public class BoatContainerClient implements ClientModInitializer {
 
 	@Override
 	public void onInitializeClient() {
-		EntityRendererRegistry.INSTANCE.register(ModEntities.CHEST_BOAT, ctx -> new BoatBlockRenderer(ctx, Blocks.CHEST.getDefaultState()));
-		EntityRendererRegistry.INSTANCE.register(ModEntities.ENDER_CHEST_BOAT, ctx -> new BoatBlockRenderer(ctx, Blocks.ENDER_CHEST.getDefaultState()));
+		EntityRendererRegistry.register(ModEntities.CHEST_BOAT,
+				ctx -> new BoatBlockRenderer(ctx, Blocks.CHEST.getDefaultState()));
+		EntityRendererRegistry.register(ModEntities.ENDER_CHEST_BOAT,
+				ctx -> new BoatBlockRenderer(ctx, Blocks.ENDER_CHEST.getDefaultState()));
 	}
 
 }


### PR DESCRIPTION
Changes:
- Just bumped up all fabric related versions to the latest
- Changes related to some deprecated API usages

Tested environment:
- CurseForge
- Fabric 0.11.7
- Boat Container 1.0.1-dev
- Fabric API 0.40.8+1.17

Crash report:
```
---- Minecraft Crash Report ----
// There are four lights!

Time: 10/16/21, 2:10 AM
Description: Initializing game

java.lang.RuntimeException: Could not execute entrypoint stage 'main' due to errors, provided by 'boatcontainer'!
	at net.fabricmc.loader.entrypoint.minecraft.hooks.EntrypointUtils.invoke0(EntrypointUtils.java:50)
	at net.fabricmc.loader.entrypoint.minecraft.hooks.EntrypointUtils.invoke(EntrypointUtils.java:33)
	at net.fabricmc.loader.entrypoint.minecraft.hooks.EntrypointClient.start(EntrypointClient.java:33)
	at net.minecraft.class_310.<init>(class_310.java:457)
	at net.minecraft.client.main.Main.main(Main.java:179)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:78)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:567)
	at net.fabricmc.loader.game.MinecraftGameProvider.launch(MinecraftGameProvider.java:234)
	at net.fabricmc.loader.launch.knot.Knot.launch(Knot.java:153)
	at net.fabricmc.loader.launch.knot.KnotClient.main(KnotClient.java:28)
Caused by: java.lang.NoClassDefFoundError: net/minecraft/util/registry/Registry
	at de.kxmischesdomi.boatcontainer.BoatContainer.onInitialize(BoatContainer.java:13)
	at net.fabricmc.loader.entrypoint.minecraft.hooks.EntrypointUtils.invoke0(EntrypointUtils.java:47)
	... 11 more
Caused by: java.lang.ClassNotFoundException: net.minecraft.util.registry.Registry
	at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:636)
	at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:182)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:519)
	at net.fabricmc.loader.launch.knot.KnotClassLoader.loadClass(KnotClassLoader.java:175)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:519)
	... 13 more


A detailed walkthrough of the error, its code path and all known details is as follows:
---------------------------------------------------------------------------------------

-- Head --
Thread: Render thread
Stacktrace:
	at net.fabricmc.loader.entrypoint.minecraft.hooks.EntrypointUtils.invoke0(EntrypointUtils.java:50)
	at net.fabricmc.loader.entrypoint.minecraft.hooks.EntrypointUtils.invoke(EntrypointUtils.java:33)
	at net.fabricmc.loader.entrypoint.minecraft.hooks.EntrypointClient.start(EntrypointClient.java:33)
	at net.minecraft.class_310.<init>(class_310.java:457)

-- Initialization --
Details:
Stacktrace:
	at net.minecraft.client.main.Main.main(Main.java:179)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:78)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:567)
	at net.fabricmc.loader.game.MinecraftGameProvider.launch(MinecraftGameProvider.java:234)
	at net.fabricmc.loader.launch.knot.Knot.launch(Knot.java:153)
	at net.fabricmc.loader.launch.knot.KnotClient.main(KnotClient.java:28)

-- System Details --
Details:
	Minecraft Version: 1.17.1
	Minecraft Version ID: 1.17.1
	Operating System: Windows 10 (amd64) version 10.0
	Java Version: 16.0.1, Microsoft
	Java VM Version: OpenJDK 64-Bit Server VM (mixed mode), Microsoft
	Memory: 1183035248 bytes (1128 MiB) / 1811939328 bytes (1728 MiB) up to 4294967296 bytes (4096 MiB)
	CPUs: 12
	Processor Vendor: GenuineIntel
	Processor Name: Intel(R) Core(TM) i7-8700K CPU @ 3.70GHz
	Identifier: Intel64 Family 6 Model 158 Stepping 10
	Microarchitecture: Coffee Lake
	Frequency (GHz): 3.70
	Number of physical packages: 1
	Number of physical CPUs: 6
	Number of logical CPUs: 12
	Graphics card #0 name: NVIDIA TITAN Xp
	Graphics card #0 vendor: NVIDIA (0x10de)
	Graphics card #0 VRAM (MB): 4095.00
	Graphics card #0 deviceId: 0x1b02
	Graphics card #0 versionInfo: DriverVersion=27.21.14.6663
	Graphics card #1 name: NVIDIA TITAN Xp
	Graphics card #1 vendor: NVIDIA (0x10de)
	Graphics card #1 VRAM (MB): 4095.00
	Graphics card #1 deviceId: 0x1b02
	Graphics card #1 versionInfo: DriverVersion=27.21.14.6663
	Memory slot #0 capacity (MB): 8192.00
	Memory slot #0 clockSpeed (GHz): 2.40
	Memory slot #0 type: DDR4
	Memory slot #1 capacity (MB): 8192.00
	Memory slot #1 clockSpeed (GHz): 2.40
	Memory slot #1 type: DDR4
	Memory slot #2 capacity (MB): 8192.00
	Memory slot #2 clockSpeed (GHz): 2.40
	Memory slot #2 type: DDR4
	Memory slot #3 capacity (MB): 8192.00
	Memory slot #3 clockSpeed (GHz): 2.40
	Memory slot #3 type: DDR4
	Virtual memory max (MB): 48575.59
	Virtual memory used (MB): 28039.58
	Swap memory total (MB): 15872.00
	Swap memory used (MB): 180.43
	JVM Flags: 5 total; -XX:HeapDumpPath=MojangTricksIntelDriversForPerformance_javaw.exe_minecraft.exe.heapdump -Xss1M -Xmx4096m -Xms256m -XX:PermSize=256m
	Fabric Mods: 
		boatcontainer: BoatContainer 1.0.1
		fabric: Fabric API 0.40.8+1.17
		fabric-api-base: Fabric API Base 0.3.0+a02b446318
		fabric-api-lookup-api-v1: Fabric API Lookup API (v1) 1.3.0+cbda931818
		fabric-biome-api-v1: Fabric Biome API (v1) 3.2.0+cbda931818
		fabric-blockrenderlayer-v1: Fabric BlockRenderLayer Registration (v1) 1.1.5+a02b446318
		fabric-command-api-v1: Fabric Command API (v1) 1.1.3+5ab9934c18
		fabric-commands-v0: Fabric Commands (v0) 0.2.2+92519afa18
		fabric-containers-v0: Fabric Containers (v0) 0.1.12+cbda931818
		fabric-content-registries-v0: Fabric Content Registries (v0) 0.3.0+cbda931818
		fabric-crash-report-info-v1: Fabric Crash Report Info (v1) 0.1.5+be9da31018
		fabric-dimensions-v1: Fabric Dimensions API (v1) 2.0.11+6cefd57718
		fabric-entity-events-v1: Fabric Entity Events (v1) 1.2.3+87cc6e4c18
		fabric-events-interaction-v0: Fabric Events Interaction (v0) 0.4.10+fc40aa9d18
		fabric-events-lifecycle-v0: Fabric Events Lifecycle (v0) 0.2.1+92519afa18
		fabric-game-rule-api-v1: Fabric Game Rule API (v1) 1.0.7+cbda931818
		fabric-item-api-v1: Fabric Item API (v1) 1.2.4+cbda931818
		fabric-item-groups-v0: Fabric Item Groups (v0) 0.2.10+b7ab612118
		fabric-key-binding-api-v1: Fabric Key Binding API (v1) 1.0.4+cbda931818
		fabric-keybindings-v0: Fabric Key Bindings (v0) 0.2.2+36b77c3e18
		fabric-lifecycle-events-v1: Fabric Lifecycle Events (v1) 1.4.4+a02b446318
		fabric-loot-tables-v1: Fabric Loot Tables (v1) 1.0.4+a02b446318
		fabric-mining-levels-v0: Fabric Mining Levels (v0) 0.1.3+92519afa18
		fabric-models-v0: Fabric Models (v0) 0.3.0+a02b446318
		fabric-networking-api-v1: Fabric Networking API (v1) 1.0.13+cbda931818
		fabric-networking-blockentity-v0: Fabric Networking Block Entity (v0) 0.2.11+a02b446318
		fabric-networking-v0: Fabric Networking (v0) 0.3.2+92519afa18
		fabric-object-builder-api-v1: Fabric Object Builder API (v1) 1.10.9+cbda931818
		fabric-object-builders-v0: Fabric Object Builders (v0) 0.7.3+a02b446318
		fabric-particles-v1: Fabric Particles (v1) 0.2.4+a02b446318
		fabric-registry-sync-v0: Fabric Registry Sync (v0) 0.7.11+7931163218
		fabric-renderer-api-v1: Fabric Renderer API (v1) 0.4.4+cbda931818
		fabric-renderer-indigo: Fabric Renderer - Indigo 0.4.8+cbda931818
		fabric-renderer-registries-v1: Fabric Renderer Registries (v1) 3.2.4+7931163218
		fabric-rendering-data-attachment-v1: Fabric Rendering Data Attachment (v1) 0.1.5+a02b446318
		fabric-rendering-fluids-v1: Fabric Rendering Fluids (v1) 0.1.14+4658223018
		fabric-rendering-v0: Fabric Rendering (v0) 1.1.5+7931163218
		fabric-rendering-v1: Fabric Rendering (v1) 1.9.0+7931163218
		fabric-resource-loader-v0: Fabric Resource Loader (v0) 0.4.8+a00e834b18
		fabric-screen-api-v1: Fabric Screen API (v1) 1.0.4+cbda931818
		fabric-screen-handler-api-v1: Fabric Screen Handler API (v1) 1.1.8+cbda931818
		fabric-structure-api-v1: Fabric Structure API (v1) 1.1.13+5ab9934c18
		fabric-tag-extensions-v0: Fabric Tag Extensions (v0) 1.2.1+b06cb95b18
		fabric-textures-v0: Fabric Textures (v0) 1.0.6+a02b446318
		fabric-tool-attribute-api-v1: Fabric Tool Attribute API (v1) 1.2.12+b7ab612118
		fabric-transfer-api-v1: Fabric Transfer API (v1) 1.4.0+7931163218
		fabricloader: Fabric Loader 0.11.7
		java: OpenJDK 64-Bit Server VM 16
		minecraft: Minecraft 1.17.1
	Launched Version: fabric-loader-0.11.7-1.17.1
	Backend library: LWJGL version 3.2.2 build 10
	Backend API: NO CONTEXT
	Window size: <not initialized>
	GL Caps: Using framebuffer using OpenGL 3.2
	GL debug messages: <disabled>
	Using VBOs: Yes
	Is Modded: Definitely; Client brand changed to 'fabric'
	Type: Client (map_client.txt)
	CPU: <unknown>
```